### PR TITLE
Add a limitation specification in README (#18)

### DIFF
--- a/README.md
+++ b/README.md
@@ -326,7 +326,7 @@ Once the ports and names are defined in the `session` task, the keywork `${ports
 
 ### Adding Tags to Ports, Emulated Devices and Stream blocks
 
-When creating Ports, Emulated Device or Stream blocks, the "tag" can be identified. 
+When creating Ports, Emulated Device or Stream blocks, the "tag" can be identified. Multiple tags are separated by SPACE in Ansible. Thus, SPACE is not allowed to define one single tag. Otherwise, it will be treated as multiple tags.
 
 ##### 1. Tag Ports
 


### PR DESCRIPTION
* Fix the issue for emulator compatible with python 2.7

* STC-I-266: support mutliple ports

* STC-I-266: updated based on comments

* STC-I-266: add more ut tests

* STC-I-266: adding exception

* STC-I-266: Update README and a typo in emulator

* Fix an emulator excetion if no ports or names defined in yaml file

* ER STC-I-265: Add tags for port, device and treamblock

* ER STC-I-265: update base on comments and add UT cases

* ER STC-I-265: add more UT

* STC-I-265: updated UT based on some comments

* STC-I-265:update UT based on some comments

* STC-I-265: add tagging in README.md

* Add a limitation specification in README

* Add a limitation specification in README

* Add a limitation specification in README

* Add a limitation specification in README

* Add a limitation specification in README